### PR TITLE
Minor changes to settings and block template

### DIFF
--- a/templates/block.tpl
+++ b/templates/block.tpl
@@ -1,10 +1,10 @@
 <div class="pkp_block block_twitter">
     <span class="title">{$tweetTitle|unescape:"html"}</span>
-    <div class="content" {if $tweetDataLimit}style="max-height: {$tweetHeight}px; overflow-y: auto;"{/if}>
+    <div class="content" {if $tweetDataLimit}style="max-height: {$tweetHeight|intval}px; overflow-y: auto;"{/if}>
         <a class="twitter-timeline" data-height="{$tweetHeight}" data-link-color="{$tweetColor}"
            href="{$tweetUrl}"
            data-chrome="{$tweetOptions}"
-           {if $tweetDataLimit}data-tweet-limit="{$tweetDataLimit}"{/if}></a>
+           {if $tweetDataLimit}data-tweet-limit="{$tweetDataLimit|intval}"{/if}></a>
         <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     </div>
 </div>

--- a/templates/settings.tpl
+++ b/templates/settings.tpl
@@ -14,15 +14,24 @@
     {csrf}
 
     {fbvFormArea}
-    {fbvFormSection}
-    {fbvElement type="text" id="tweetTitle" value=$tweetTitle label="plugins.blocks.twitter.tweet.title"}
-    {fbvElement type="text" id="tweetUrl" value=$tweetUrl label="plugins.blocks.twitter.tweet.url"}
-    {fbvElement type="text" id="tweetColor" value=$tweetColor label="plugins.blocks.twitter.tweet.color"}
-    {fbvElement type="text" id="tweetHeight" value=$tweetHeight label="plugins.blocks.twitter.tweet.height"}
-    {fbvElement type="text" id="tweetOptions" value=$tweetOptions label="plugins.blocks.twitter.tweet.options"}
-    {fbvElement type="text" id="tweetDataLimit" value=$tweetDataLimit label="plugins.blocks.twitter.tweet.limit"}
-
-    {/fbvFormSection}
+			{fbvFormSection title="plugins.blocks.twitter.tweet.title"}
+				{fbvElement type="text" id="tweetTitle" value=$tweetTitle}
+			{/fbvFormSection}
+			{fbvFormSection title="plugins.blocks.twitter.tweet.url"}
+				{fbvElement type="text" id="tweetUrl" value=$tweetUrl}
+			{/fbvFormSection}
+			{fbvFormSection title="plugins.blocks.twitter.tweet.color"}
+				{fbvElement type="text" id="tweetColor" value=$tweetColor}
+			{/fbvFormSection}
+			{fbvFormSection title="plugins.blocks.twitter.tweet.height"}
+				{fbvElement type="text" id="tweetHeight" value=$tweetHeight}
+			{/fbvFormSection}
+			{fbvFormSection title="plugins.blocks.twitter.tweet.options"}
+				{fbvElement type="text" id="tweetOptions" value=$tweetOptions}
+			{/fbvFormSection}
+			{fbvFormSection title="plugins.blocks.twitter.tweet.limit"}
+				{fbvElement type="text" id="tweetDataLimit" value=$tweetDataLimit}
+			{/fbvFormSection}
     {/fbvFormArea}
     {fbvFormButtons submitText="common.save"}
 </form>


### PR DESCRIPTION
- Use section titles so that the setting forms look like other settings forms in the application.
- Convert some of the settings values to `int` before using them in the template.